### PR TITLE
Adds backwards compatibility for Headscale v0.22 and lower.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 
 This is a static headscale admin ui, no backend enviroment required
 
+The current release is backward compatible with headscale v0.22 as well as compatible with the future headscale v0.23;
+
 ## Thanks
 
 Headscale - https://github.com/juanfont/headscale  version: v0.21.0

--- a/angular.json
+++ b/angular.json
@@ -107,5 +107,8 @@
         }
       }
     }
+  },
+  "cli": {
+    "analytics": false
   }
 }

--- a/src/app/api.service.ts
+++ b/src/app/api.service.ts
@@ -12,39 +12,84 @@ export class ApiService {
 
   ///Machine api start
   machineList(user: string): Observable<any> {
-    return this.http.get(`/api/v1/node?user=${user}`)
+    let version = localStorage.getItem('hsVersion') ?? 'v0.23';
+    if (version == 'v0.23'){
+      return this.http.get(`/api/v1/node?user=${user}`)
+    }else{
+      return this.http.get(`/api/v1/machine?user=${user}`)
+    }
   }
 
   machineRegister(user: string, key: string): Observable<any> {
-    return this.http.post(`/api/v1/node/register?user=${user}&key=${key}`, null);
+    let version = localStorage.getItem('hsVersion') ?? 'v0.23';
+    if (version == 'v0.23'){
+      return this.http.post(`/api/v1/node/register?user=${user}&key=${key}`, null);  
+    }else{
+      return this.http.post(`/api/v1/machine/register?user=${user}&key=${key}`, null);
+    }
   }
 
   machineDetail(machineId: string): Observable<any> {
-    return this.http.get(`/api/v1/node/${machineId}`);
+    let version = localStorage.getItem('hsVersion') ?? 'v0.23';
+    if (version == 'v0.23'){
+      return this.http.get(`/api/v1/node/${machineId}`);  
+    }else{
+      return this.http.get(`/api/v1/machine/${machineId}`);
+    }
   }
 
   machineExpire(machineId: string): Observable<any> {
-    return this.http.post(`/api/v1/node/${machineId}/expire`, null);
+    let version = localStorage.getItem('hsVersion') ?? 'v0.23';
+    if (version == 'v0.23'){
+      return this.http.post(`/api/v1/node/${machineId}/expire`, null);  
+    }else{
+      return this.http.post(`/api/v1/machine/${machineId}/expire`, null);
+    }
   }
 
   machineDelete(machineId: string): Observable<any> {
-    return this.http.delete(`/api/v1/node/${machineId}`);
+    let version = localStorage.getItem('hsVersion') ?? 'v0.23';
+    if (version == 'v0.23'){
+      return this.http.delete(`/api/v1/node/${machineId}`);  
+    }else{
+      return this.http.delete(`/api/v1/machine/${machineId}`);
+    }
   }
 
   machineRename(machineId: string, name: string): Observable<any> {
-    return this.http.post(`/api/v1/node/${machineId}/rename/${name}`, null);
+    let version = localStorage.getItem('hsVersion') ?? 'v0.23';
+    if (version == 'v0.23'){
+      return this.http.post(`/api/v1/node/${machineId}/rename/${name}`, null);  
+    }else{
+      return this.http.post(`/api/v1/machine/${machineId}/rename/${name}`, null);
+    }
   }
 
   machineRoutes(machineId: string): Observable<any> {
-    return this.http.get(`/api/v1/node/${machineId}/routes`);
+    let version = localStorage.getItem('hsVersion') ?? 'v0.23';
+    if (version == 'v0.23'){
+      return this.http.get(`/api/v1/node/${machineId}/routes`);  
+    }else{
+      return this.http.get(`/api/v1/machine/${machineId}/routes`);
+    }
   }
 
   machineTag(machineId: string, tags: Array<string>): Observable<any> {
-    return this.http.post(`/api/v1/node/${machineId}/tags`, {tags});
+    let version = localStorage.getItem('hsVersion') ?? 'v0.23';
+    if (version == 'v0.23'){
+      return this.http.post(`/api/v1/node/${machineId}/tags`, {tags});  
+    }else{
+      return this.http.post(`/api/v1/machine/${machineId}/tags`, {tags});
+    }
   }
 
   machineChangeUser(machineId: string, user: string): Observable<any> {
-    return this.http.post(`/api/v1/node/${machineId}/user?user=${user}`, null);
+    let version = localStorage.getItem('hsVersion') ?? 'v0.23';
+    if (version == 'v0.23'){
+      return this.http.post(`/api/v1/node/${machineId}/user?user=${user}`, null);  
+    }else{
+      return this.http.post(`/api/v1/machine/${machineId}/user?user=${user}`, null);
+    }
   }
 
 

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -4,9 +4,9 @@ import {BrowserModule} from '@angular/platform-browser';
 import {AppRoutingModule} from './app-routing.module';
 import {AppComponent} from './app.component';
 import {NZ_I18N} from 'ng-zorro-antd/i18n';
-import {zh_CN} from 'ng-zorro-antd/i18n';
+import {en_US} from 'ng-zorro-antd/i18n';
 import {HashLocationStrategy, LocationStrategy, registerLocaleData} from '@angular/common';
-import zh from '@angular/common/locales/zh';
+import en from '@angular/common/locales/en';
 import {FormsModule} from '@angular/forms';
 import {HTTP_INTERCEPTORS, HttpClientModule} from '@angular/common/http';
 import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
@@ -35,7 +35,7 @@ import {NzGridModule} from 'ng-zorro-antd/grid';
 import {NzListModule} from 'ng-zorro-antd/list';
 import {NzSelectModule} from 'ng-zorro-antd/select';
 
-registerLocaleData(zh);
+registerLocaleData(en);
 
 @NgModule({
   declarations: [
@@ -72,7 +72,7 @@ registerLocaleData(zh);
     NzSelectModule
   ],
   providers: [
-    {provide: NZ_I18N, useValue: zh_CN},
+    {provide: NZ_I18N, useValue: en_US},
     {provide: LocationStrategy, useClass: HashLocationStrategy},
     {provide: HTTP_INTERCEPTORS, useClass: HttpApiInterceptor, multi: true}
   ],

--- a/src/app/http-api.interceptor.ts
+++ b/src/app/http-api.interceptor.ts
@@ -24,13 +24,14 @@ export class HttpApiInterceptor implements HttpInterceptor {
       url: (localStorage.getItem('serverUrl') ?? '') + request.url
     });
     return next.handle(resetReq).pipe(catchError((error: any): Observable<any> => {
-      this.msg.error(error.error.message ?? error.error);
       if (error.error === 'Unauthorized') {
+        this.msg.error(error.error.message ?? error.error);
         localStorage.setItem('serverKey', '');
         this.router.navigateByUrl('/login');
       }
       if (error.status === 404 || error.status == 0) {
-        this.router.navigateByUrl('/login');
+        this.msg.error("Error message: " + error.error.message + "<br />API endpoint not found, either Headscale Url or version is wrong. <br /> Exit and configure the correct URL and version.");
+        //this.router.navigateByUrl('/login');
       }
       return of(error)
     }));

--- a/src/app/http-api.interceptor.ts
+++ b/src/app/http-api.interceptor.ts
@@ -31,7 +31,9 @@ export class HttpApiInterceptor implements HttpInterceptor {
       }
       if (error.status === 404 || error.status == 0) {
         this.msg.error("Error message: " + error.error.message + "<br />API endpoint not found, either Headscale Url or version is wrong. <br /> Exit and configure the correct URL and version.");
-        //this.router.navigateByUrl('/login');
+        if(localStorage.getItem('serverKey') == null){
+          this.router.navigateByUrl('/login');
+        }
       }
       return of(error)
     }));

--- a/src/app/views/login/login.component.html
+++ b/src/app/views/login/login.component.html
@@ -1,24 +1,55 @@
-<nz-card style="width:450px; left:calc(50% - 225px);position: fixed; top:calc(50% - 160px)"
-         [nzTitle]="titleTpl" [nzExtra]="extraTemplate">
-  <ng-container *ngIf="serverUrl && serverUrl!=='/'">
+<nz-card
+  style="
+    width: 450px;
+    left: calc(50% - 225px);
+    position: fixed;
+    top: calc(50% - 160px);
+  "
+  [nzTitle]="titleTpl"
+  [nzExtra]="extraTemplate"
+>
+  <ng-container *ngIf="serverUrl && serverUrl !== '/'">
     <p>Server Url:</p>
-    <p>{{serverUrl}}</p>
+    <p>{{ serverUrl }}</p>
   </ng-container>
   <p>ApiKeys:</p>
-  <p><input nz-input [(ngModel)]="apiKeys"/></p>
+  <p><input nz-input [(ngModel)]="apiKeys" /></p>
   <p>
-    <button (click)="doLogin()" nz-button nzType="primary" nzSize="large" nzBlock>Login</button>
+    <button
+      (click)="doLogin()"
+      nz-button
+      nzType="primary"
+      nzSize="large"
+      nzBlock
+    >
+      Login
+    </button>
   </p>
 </nz-card>
 <ng-template #extraTemplate>
   <a (click)="showChangeServer()">Change Server</a>
 </ng-template>
 <ng-template #titleTpl>
-  <img src="./assets/simcu.png" width="30"> Server Login
+  <img src="./assets/simcu.png" width="30" /> Server Login
 </ng-template>
-<nz-modal [(nzVisible)]="changeServerShow" nzTitle="Change Server" (nzOnCancel)="handleCancel()" (nzOnOk)="handleOk()">
+<nz-modal
+  [(nzVisible)]="changeServerShow"
+  nzTitle="Change Server"
+  (nzOnCancel)="handleCancel()"
+  (nzOnOk)="handleOk()"
+>
   <ng-container *nzModalContent>
     <p>Server Url:</p>
-    <p><input nz-input [(ngModel)]="changeServerUrl"/></p>
+    <p><input nz-input [(ngModel)]="changeServerUrl" /></p>
+    <p>HS Version</p>
+    <!-- Select Version -->
+    <nz-select
+      [(ngModel)]="hsVersion"
+      nzPlaceHolder="Select Version"
+      style="width: 100%"
+    >
+      <nz-option nzValue="v0.23" nzLabel="Versio v0.23 and above"></nz-option>
+      <nz-option nzValue="v0.22" nzLabel="Version v0.22 and lower"></nz-option>
+    </nz-select>
   </ng-container>
 </nz-modal>

--- a/src/app/views/login/login.component.ts
+++ b/src/app/views/login/login.component.ts
@@ -12,6 +12,7 @@ export class LoginComponent implements OnInit {
   serverUrl = '/';
   apiKeys = '';
   changeServerUrl = '';
+  hsVersion = '';
 
   changeServerShow = false;
 
@@ -39,7 +40,7 @@ export class LoginComponent implements OnInit {
     this.api.userList().subscribe(x => {
       this.router.navigateByUrl('');
     }, error => {
-      this.msg.error(error.error);
+      this.msg.error(error.error + 'teste');
     });
   }
 
@@ -49,12 +50,21 @@ export class LoginComponent implements OnInit {
     } else {
       this.serverUrl = this.changeServerUrl;
     }
+    
+    if(!this.hsVersion){
+      this.hsVersion = 'v0.23';
+    } else {
+      this.hsVersion = this.hsVersion
+    }
+
     localStorage.setItem('serverUrl', this.serverUrl);
+    localStorage.setItem('hsVersion', this.hsVersion);
     this.changeServerShow = false;
   }
 
   showChangeServer() {
-    this.changeServerUrl = '';
+
+    this.changeServerUrl = localStorage.getItem('serverUrl') ?? '';
     this.changeServerShow = true;
   }
 

--- a/src/app/views/machine-manager/machine-manager.component.ts
+++ b/src/app/views/machine-manager/machine-manager.component.ts
@@ -50,13 +50,21 @@ export class MachineManagerComponent implements OnInit {
   }
 
   getList() {
-    this.api.machineList(this.user).subscribe(x => {
-      this.machines = x.nodes.sort((a: any, b: any) => parseInt(a.id) - parseInt(b.id));
-      this.getRoutes();
-      if (this.tagEditMachine.id) {
-        this.tagEditMachine = this.machines.find(x => x.id == this.tagEditMachine.id);
-      }
-    })
+    let version = localStorage.getItem('serverUrl') ?? 'v0.23';
+
+      this.api.machineList(this.user).subscribe(x => {
+        if (version === 'v0.23'){
+          this.machines = x.nodes.sort((a: any, b: any) => parseInt(a.id) - parseInt(b.id));
+        }else{
+          this.machines = x.machines.sort((a: any, b: any) => parseInt(a.id) - parseInt(b.id));
+        }
+        this.getRoutes();
+        if (this.tagEditMachine.id) {
+          this.tagEditMachine = this.machines.find(x => x.id == this.tagEditMachine.id);
+        }
+      });
+    
+    
   }
 
   getRoutes() {


### PR DESCRIPTION
Adds logic to handle the selection of the API version, allowing it to be backwards compatible with the API requests still used in version 0.22 and lower of Headscale.

This PR also corrects Internationalization of the NZ-ZORRO ui framework unifying the UI to English.

README updated to also alert for the selection of the API version.

Fixes #13 