### PR TITLE
Fix route list and support deleting routes

### DIFF
--- a/src/app/views/machine-manager/machine-manager.component.html
+++ b/src/app/views/machine-manager/machine-manager.component.html
@@ -116,9 +116,24 @@
                 <span *ngIf="eni.prefix==='::/0'">IPv6</span>&nbsp;
                  <nz-tag nzColor="geekblue" *ngIf="eni.enabled">Enabled</nz-tag>
                  <nz-tag nzColor="default" *ngIf="!eni.enabled">Disabled</nz-tag>
+                 <nz-tag nzColor="pink" *ngIf="!eni.advertised">Not advertised</nz-tag>
               </span>
-              <a nz-button nzType="default" *ngIf="!eni.enabled" (click)="enableRoute(eni.id)">Enable</a>
-              <a nz-button nzType="default" *ngIf="eni.enabled" (click)="disableRoute(eni.id)">Disable</a>
+              <span>
+                <nz-button-group>
+                  <button nz-button nzType="default" *ngIf="!eni.enabled" [disabled]="!eni.advertised" (click)="enableRoute(eni.id)">Enable</button>
+                  <button nz-button nzType="default" *ngIf="eni.enabled" (click)="disableRoute(eni.id)">Disable</button>
+                  <button nz-button nz-dropdown [nzDropdownMenu]="menu2" nzPlacement="bottomRight">
+                    <span nz-icon nzType="ellipsis"></span>
+                  </button>
+                </nz-button-group>
+                <nz-dropdown-menu #menu2="nzDropdownMenu">
+                  <ul nz-menu>
+                    <li nz-menu-item>
+                      <a nz-button nzDanger nzType="link" nzSize="small" (click)="deleteRoute(eni.id)">Delete Route</a>
+                    </li>
+                  </ul>
+                </nz-dropdown-menu>
+              </span>
             </nz-list-item>
           </nz-list>
           <nz-list nzBordered nzHeader="Sub Nets" nzSize="small" *ngIf="data.subnets && data.subnets.length>0">
@@ -130,8 +145,22 @@
                  <nz-tag nzColor="orange" *ngIf="sni.isPrimary">Primary</nz-tag>
                  <nz-tag nzColor="pink" *ngIf="!sni.advertised">Not advertised</nz-tag>
               </span>
-              <a nz-button nzType="default" *ngIf="!sni.enabled" (click)="enableRoute(sni.id)">Enable</a>
-              <a nz-button nzType="default" *ngIf="sni.enabled" (click)="disableRoute(sni.id)">Disable</a>
+              <span>
+                <nz-button-group>
+                  <button nz-button nzType="default" *ngIf="!sni.enabled" [disabled]="!sni.advertised" (click)="enableRoute(sni.id)">Enable</button>
+                  <button nz-button nzType="default" *ngIf="sni.enabled" (click)="disableRoute(sni.id)">Disable</button>
+                  <button nz-button nz-dropdown [nzDropdownMenu]="menu3" nzPlacement="bottomRight">
+                    <span nz-icon nzType="ellipsis"></span>
+                  </button>
+                </nz-button-group>
+                <nz-dropdown-menu #menu3="nzDropdownMenu">
+                  <ul nz-menu>
+                    <li nz-menu-item>
+                      <a nz-button nzDanger nzType="link" nzSize="small" (click)="deleteRoute(sni.id)">Delete Route</a>
+                    </li>
+                  </ul>
+                </nz-dropdown-menu>
+              </span>
             </nz-list-item>
           </nz-list>
         </div>

--- a/src/app/views/machine-manager/machine-manager.component.html
+++ b/src/app/views/machine-manager/machine-manager.component.html
@@ -127,6 +127,8 @@
                 {{sni.prefix}}&nbsp;
                  <nz-tag nzColor="geekblue" *ngIf="sni.enabled">Enabled</nz-tag>
                  <nz-tag nzColor="default" *ngIf="!sni.enabled">Disabled</nz-tag>
+                 <nz-tag nzColor="orange" *ngIf="sni.isPrimary">Primary</nz-tag>
+                 <nz-tag nzColor="pink" *ngIf="!sni.advertised">Not advertised</nz-tag>
               </span>
               <a nz-button nzType="default" *ngIf="!sni.enabled" (click)="enableRoute(sni.id)">Enable</a>
               <a nz-button nzType="default" *ngIf="sni.enabled" (click)="disableRoute(sni.id)">Disable</a>

--- a/src/app/views/machine-manager/machine-manager.component.ts
+++ b/src/app/views/machine-manager/machine-manager.component.ts
@@ -145,6 +145,13 @@ export class MachineManagerComponent implements OnInit {
     })
   }
 
+  deleteRoute(id: string) {
+    this.api.routeDelete(id).subscribe(x => {
+      this.msg.success('Route Delete success');
+      this.getList();
+    })
+  }
+
   userChange(e: any) {
     if (e) {
       this.router.navigateByUrl(`/machine?user=${e}`)

--- a/src/app/views/machine-manager/machine-manager.component.ts
+++ b/src/app/views/machine-manager/machine-manager.component.ts
@@ -62,7 +62,7 @@ export class MachineManagerComponent implements OnInit {
   getRoutes() {
     this.api.routeList().subscribe(x => {
       for (let r of x.routes) {
-        let m = this.machines.find(x => x.id === r.machine.id);
+        let m = this.machines.find(x => x.id === r.node.id);
         if (m) {
           if (['0.0.0.0/0', '::/0'].indexOf(r.prefix) !== -1) {
             if (m['exitNodes']) {


### PR DESCRIPTION
- Rename `machine` to `node` in response to changes in the Headscale API.
- Add tag `Not advertised` and include a button to delete unnecessary routes.
- Add tag `Primary`, which is useful when multiple nodes advertise the same route.