### PR TITLE
Update UI for headscale 0.28 API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,64 +1,124 @@
-# HeadscaleUi
+# Headscale UI
 [![main](https://github.com/simcu/headscale-ui/actions/workflows/main.yml/badge.svg)](https://github.com/simcu/headscale-ui/actions/workflows/main.yml)
 
-This is a static headscale admin ui, no backend enviroment required
+Headscale UI is a static admin interface for Headscale. It does not require its own backend service and can be served by any static web server.
 
-The current release is backward compatible with headscale v0.22 as well as compatible with the future headscale v0.23;
+## Compatibility
 
-## Thanks
+This fork has been updated for Headscale `v0.28`.
 
-Headscale - https://github.com/juanfont/headscale  version: v0.21.0
+Current support status:
 
-UI - https://github.com/NG-ZORRO/ng-zorro-antd  version: v15.0.3
+- `v0.28`: supported
+- `v0.23` to `v0.27`: login option kept for compatibility, but this release is primarily validated against `v0.28`
+- `v0.22` and below: legacy option still exists in the login screen, but not covered by the latest validation
 
-BaseFramework - https://angular.io/ version: 15.2.4
+## What Changed For Headscale v0.28
 
+Headscale `v0.28` changed several API behaviors compared with older releases. This update aligns the UI with the newer API by:
 
-## ScreenShots
+- switching machine operations to the `/api/v1/node` endpoints
+- updating user operations to use user IDs where required by newer API handlers
+- updating pre-auth key operations to use the current request and response shapes
+- updating route approval actions to use node route approval APIs instead of the old route management flow
+- adjusting login defaults to prefer `v0.28`
+- improving request handling and error messages during login
 
-<img width="1371" alt="image" src="https://user-images.githubusercontent.com/11401602/227347953-130835c6-7f58-4227-9a83-c6b40b9c2427.png">
-<img width="1371" alt="image" src="https://user-images.githubusercontent.com/11401602/227347584-905dd1e8-8b99-4292-8424-2f0e1399a031.png">
-<img width="1371" alt="image" src="https://user-images.githubusercontent.com/11401602/227347766-1d9d81c2-5e5a-43fb-ac3d-80d3a04c2f8c.png">
+## API Compatibility Note
 
-## Pre Requirement
-1. You need to generate a apikey use headscale-cli
-> on your headscale server run: headscale apikeys create -e 9999d
-2. You need a static web server space, or use docker
-3. (optional) If you deploy it on other domain, you need set headscale api's cors.
+This update removes the old version-switching logic for the legacy machine endpoints in the Angular API service.
 
-## Deploy Guide
-### A: use static web space
-emmm.... I don't know how to describe this action.... it is really very easy... 
+In practice:
 
-### B: use docker (k8s also, it's a nginx static webserver, no other required)
+- the UI now uses the Headscale `v0.28` node APIs as the primary implementation
+- legacy `/api/v1/machine/...` request branches were removed from the client service
+- legacy standalone route management calls were also removed from the client service
+- route updates are now performed through node approved-route APIs
 
-1. run command on your docker enviroment
+To reduce UI churn, several Angular service method names still keep the historical `machine*` naming, but they now call `/api/v1/node/...` endpoints internally.
 
-> docker run -d --name headscale-ui -p 8888:80 simcu/headscale-ui
+This means the current codebase is no longer a full dual-path implementation for both old `machine` APIs and newer `node` APIs.
 
-2. open http://127.0.0.1:8888/manager/ 
+## Current Functional Notes
 
-3. (optional)  if run it not on same domain with headscale,the system will error, don't warried, only click "Exit" on the top menu, you will redirect to login page.
+The `v0.28` flow was validated for:
 
-4.  if you deploy this standalone, on login page click "Change Server" then, input server url.
-5. input apikey , click "Login"
+- login
+- user listing, rename, and delete
+- node listing
+- node registration
+- node rename
+- node expiry and delete
+- route approval and removal through approved routes
+- pre-auth key list, create, and expire
 
-### C: use caddy
+Known limitation in `v0.28` mode:
+
+- tag editing is currently shown as read-only in the machine view
+
+## Requirements
+
+1. Generate an API key with the Headscale CLI:
+
+   ```bash
+   headscale apikeys create -e 9999d
+   ```
+
+2. Host the built UI on a static web server, or run it with Docker
+3. If the UI is hosted on a different origin from Headscale, configure CORS on the Headscale side
+
+## Deployment
+
+### Static Hosting
+
+Build the application and serve the output directory with any static web server.
+
+### Docker
+
+```bash
+docker run -d --name headscale-ui -p 8888:80 simcu/headscale-ui
 ```
-domain.com {
-        @ui {
-                path_regexp (/$)|(\.)
-        }
-        handle @ui {
-                root * /www/headscale-ui
-                try_files {path} /index.html
-                file_server
-        }
 
-        reverse_proxy 127.0.0.1:7070
+Then open:
+
+```text
+http://127.0.0.1:8888/manager/
+```
+
+If the UI is not hosted on the same origin as Headscale:
+
+1. open the login page
+2. click `Change Server`
+3. enter the Headscale server URL
+4. enter the API key
+5. log in
+
+### Caddy Example
+
+```caddy
+domain.com {
+    @ui {
+        path_regexp (/$)|(\.)
+    }
+
+    handle @ui {
+        root * /www/headscale-ui
+        try_files {path} /index.html
+        file_server
+    }
+
+    reverse_proxy 127.0.0.1:7070
 }
 ```
 
-## Notice
-1. ServerUrl and ApiKey are saved in localstorage in plain text. 
-2. you will only need login once.if apikey is invalid , system will require login again.
+## Security Notice
+
+- `serverUrl` and `apiKey` are stored in `localStorage` in plain text
+- users usually only need to log in once
+- if the API key becomes invalid, the UI will require login again
+
+## Credits
+
+- Headscale: https://github.com/juanfont/headscale
+- NG-ZORRO: https://github.com/NG-ZORRO/ng-zorro-antd
+- Angular: https://angular.io/

--- a/src/app/api.service.ts
+++ b/src/app/api.service.ts
@@ -12,84 +12,36 @@ export class ApiService {
 
   ///Machine api start
   machineList(user: string): Observable<any> {
-    let version = localStorage.getItem('hsVersion') ?? 'v0.23';
-    if (version == 'v0.23'){
-      return this.http.get(`/api/v1/node?user=${user}`)
-    }else{
-      return this.http.get(`/api/v1/machine?user=${user}`)
-    }
+    const url = user ? `/api/v1/node?user=${encodeURIComponent(user)}` : '/api/v1/node';
+    return this.http.get(url);
   }
 
   machineRegister(user: string, key: string): Observable<any> {
-    let version = localStorage.getItem('hsVersion') ?? 'v0.23';
-    if (version == 'v0.23'){
-      return this.http.post(`/api/v1/node/register?user=${user}&key=${key}`, null);  
-    }else{
-      return this.http.post(`/api/v1/machine/register?user=${user}&key=${key}`, null);
-    }
+    return this.http.post(`/api/v1/node/register?user=${encodeURIComponent(user)}&key=${encodeURIComponent(key)}`, null);
   }
 
   machineDetail(machineId: string): Observable<any> {
-    let version = localStorage.getItem('hsVersion') ?? 'v0.23';
-    if (version == 'v0.23'){
-      return this.http.get(`/api/v1/node/${machineId}`);  
-    }else{
-      return this.http.get(`/api/v1/machine/${machineId}`);
-    }
+    return this.http.get(`/api/v1/node/${machineId}`);
   }
 
   machineExpire(machineId: string): Observable<any> {
-    let version = localStorage.getItem('hsVersion') ?? 'v0.23';
-    if (version == 'v0.23'){
-      return this.http.post(`/api/v1/node/${machineId}/expire`, null);  
-    }else{
-      return this.http.post(`/api/v1/machine/${machineId}/expire`, null);
-    }
+    return this.http.post(`/api/v1/node/${machineId}/expire`, null);
   }
 
   machineDelete(machineId: string): Observable<any> {
-    let version = localStorage.getItem('hsVersion') ?? 'v0.23';
-    if (version == 'v0.23'){
-      return this.http.delete(`/api/v1/node/${machineId}`);  
-    }else{
-      return this.http.delete(`/api/v1/machine/${machineId}`);
-    }
+    return this.http.delete(`/api/v1/node/${machineId}`);
   }
 
   machineRename(machineId: string, name: string): Observable<any> {
-    let version = localStorage.getItem('hsVersion') ?? 'v0.23';
-    if (version == 'v0.23'){
-      return this.http.post(`/api/v1/node/${machineId}/rename/${name}`, null);  
-    }else{
-      return this.http.post(`/api/v1/machine/${machineId}/rename/${name}`, null);
-    }
-  }
-
-  machineRoutes(machineId: string): Observable<any> {
-    let version = localStorage.getItem('hsVersion') ?? 'v0.23';
-    if (version == 'v0.23'){
-      return this.http.get(`/api/v1/node/${machineId}/routes`);  
-    }else{
-      return this.http.get(`/api/v1/machine/${machineId}/routes`);
-    }
+    return this.http.post(`/api/v1/node/${machineId}/rename/${encodeURIComponent(name)}`, null);
   }
 
   machineTag(machineId: string, tags: Array<string>): Observable<any> {
-    let version = localStorage.getItem('hsVersion') ?? 'v0.23';
-    if (version == 'v0.23'){
-      return this.http.post(`/api/v1/node/${machineId}/tags`, {tags});  
-    }else{
-      return this.http.post(`/api/v1/machine/${machineId}/tags`, {tags});
-    }
+    return this.http.post(`/api/v1/node/${machineId}/tags`, {nodeId: machineId, tags});
   }
 
-  machineChangeUser(machineId: string, user: string): Observable<any> {
-    let version = localStorage.getItem('hsVersion') ?? 'v0.23';
-    if (version == 'v0.23'){
-      return this.http.post(`/api/v1/node/${machineId}/user?user=${user}`, null);  
-    }else{
-      return this.http.post(`/api/v1/machine/${machineId}/user?user=${user}`, null);
-    }
+  machineSetApprovedRoutes(machineId: string, routes: Array<string>): Observable<any> {
+    return this.http.post(`/api/v1/node/${machineId}/approve_routes`, {nodeId: machineId, routes});
   }
 
 
@@ -102,51 +54,25 @@ export class ApiService {
     return this.http.post('/api/v1/user', {name});
   }
 
-  userDetail(name: string): Observable<any> {
-    return this.http.get(`/api/v1/user/${name}`);
+  userDelete(id: string): Observable<any> {
+    return this.http.delete(`/api/v1/user/${id}`);
   }
 
-  userDelete(name: string): Observable<any> {
-    return this.http.delete(`/api/v1/user/${name}`);
-  }
-
-  userRename(old: string, name: string): Observable<any> {
-    return this.http.post(`/api/v1/user/${old}/rename/${name}`, {});
-  }
-
-
-  ///route api start
-  routeList(): Observable<any> {
-    return this.http.get(`/api/v1/routes`);
-  }
-
-  routeDelete(id: string): Observable<any> {
-    return this.http.delete(`/api/v1/routes/${id}`);
-  }
-
-  routeEnable(id: string): Observable<any> {
-    return this.http.post(`/api/v1/routes/${id}/enable`, null);
-  }
-
-  routeDisable(id: string): Observable<any> {
-    return this.http.post(`/api/v1/routes/${id}/disable`, null);
+  userRename(id: string, name: string): Observable<any> {
+    return this.http.post(`/api/v1/user/${id}/rename/${encodeURIComponent(name)}`, {});
   }
 
   ///preauth key start
-  preAuthKeyList(user: string): Observable<any> {
-    var url = `/api/v1/preauthkey`
-    if (user) {
-      url = `/api/v1/preauthkey?user=${user}`;
-    }
-    return this.http.get(url);
+  preAuthKeyList(): Observable<any> {
+    return this.http.get('/api/v1/preauthkey');
   }
 
-  preAuthKeyAdd(user: string, expiration: string, aclTags: Array<string> = [], reusable = false, ephemeral = false): Observable<any> {
-    return this.http.post('/api/v1/preauthkey', {user, reusable, ephemeral, aclTags, expiration})
+  preAuthKeyAdd(userId: string, expiration: string, aclTags: Array<string> = [], reusable = false, ephemeral = false): Observable<any> {
+    return this.http.post('/api/v1/preauthkey', {user: userId, reusable, ephemeral, aclTags, expiration});
   }
 
-  preAuthKeyExpire(user: string, key: string): Observable<any> {
-    return this.http.post('/api/v1/preauthkey/expire', {user, key});
+  preAuthKeyExpire(id: string): Observable<any> {
+    return this.http.post('/api/v1/preauthkey/expire', {id});
   }
 
   ///api key start

--- a/src/app/http-api.interceptor.ts
+++ b/src/app/http-api.interceptor.ts
@@ -3,22 +3,23 @@ import {
   HttpRequest,
   HttpHandler,
   HttpEvent,
-  HttpInterceptor, HttpResponse
+  HttpInterceptor
 } from '@angular/common/http';
-import {catchError, mergeMap, Observable, of} from 'rxjs';
-import {ActivatedRoute, Router} from '@angular/router';
+import {catchError, Observable, of} from 'rxjs';
+import {Router} from '@angular/router';
 import {NzMessageService} from 'ng-zorro-antd/message';
 
 @Injectable()
 export class HttpApiInterceptor implements HttpInterceptor {
 
-  constructor(private router: Router, private msg: NzMessageService, private route: ActivatedRoute) {
+  constructor(private router: Router, private msg: NzMessageService) {
   }
 
   intercept(request: HttpRequest<unknown>, next: HttpHandler): Observable<HttpEvent<unknown>> {
+    const serverKey = localStorage.getItem('serverKey') ?? '';
     const resetReq = request.clone({
       setHeaders: {
-        'Authorization': 'Bearer ' + localStorage.getItem('serverKey') ?? '',
+        Authorization: serverKey ? `Bearer ${serverKey}` : '',
         'Content-Type': 'application/json'
       },
       url: (localStorage.getItem('serverUrl') ?? '') + request.url

--- a/src/app/views/login/login.component.html
+++ b/src/app/views/login/login.component.html
@@ -48,7 +48,8 @@
       nzPlaceHolder="Select Version"
       style="width: 100%"
     >
-      <nz-option nzValue="v0.23" nzLabel="Versio v0.23 and above"></nz-option>
+      <nz-option nzValue="v0.28" nzLabel="Version v0.28"></nz-option>
+      <nz-option nzValue="v0.23" nzLabel="Version v0.23-v0.27"></nz-option>
       <nz-option nzValue="v0.22" nzLabel="Version v0.22 and lower"></nz-option>
     </nz-select>
   </ng-container>

--- a/src/app/views/login/login.component.ts
+++ b/src/app/views/login/login.component.ts
@@ -9,7 +9,7 @@ import {NzMessageService} from 'ng-zorro-antd/message';
   styleUrls: ['./login.component.css']
 })
 export class LoginComponent implements OnInit {
-  serverUrl = '/';
+  serverUrl = '';
   apiKeys = '';
   changeServerUrl = '';
   hsVersion = '';
@@ -20,8 +20,10 @@ export class LoginComponent implements OnInit {
   }
 
   ngOnInit() {
-    this.serverUrl = localStorage.getItem('serverUrl') ?? '/';
-    let apikey = localStorage.getItem('serverKey') ?? '';
+    this.serverUrl = localStorage.getItem('serverUrl') ?? '';
+    this.apiKeys = localStorage.getItem('serverKey') ?? '';
+    this.hsVersion = localStorage.getItem('hsVersion') ?? 'v0.28';
+    let apikey = this.apiKeys;
     if (apikey) {
       this.checkLogin();
     }
@@ -37,10 +39,10 @@ export class LoginComponent implements OnInit {
   }
 
   checkLogin() {
-    this.api.userList().subscribe(x => {
+    this.api.userList().subscribe(() => {
       this.router.navigateByUrl('');
     }, error => {
-      this.msg.error(error.error + 'teste');
+      this.msg.error(error.error?.message ?? error.error ?? 'Login failed');
     });
   }
 
@@ -51,10 +53,8 @@ export class LoginComponent implements OnInit {
       this.serverUrl = this.changeServerUrl;
     }
     
-    if(!this.hsVersion){
-      this.hsVersion = 'v0.23';
-    } else {
-      this.hsVersion = this.hsVersion
+    if (!this.hsVersion) {
+      this.hsVersion = 'v0.28';
     }
 
     localStorage.setItem('serverUrl', this.serverUrl);
@@ -63,8 +63,8 @@ export class LoginComponent implements OnInit {
   }
 
   showChangeServer() {
-
     this.changeServerUrl = localStorage.getItem('serverUrl') ?? '';
+    this.hsVersion = localStorage.getItem('hsVersion') ?? 'v0.28';
     this.changeServerShow = true;
   }
 

--- a/src/app/views/machine-manager/machine-manager.component.html
+++ b/src/app/views/machine-manager/machine-manager.component.html
@@ -25,7 +25,7 @@
   </tr>
   </thead>
   <tbody>
-  <ng-container *ngFor="let data of nzTable.data">
+  <ng-container *ngFor="let data of nzTable.data; trackBy: machineTrackBy">
     <tr>
       <td [nzExpand]="expandSet.has(data.id)" (nzExpandChange)="onExpandChange(data.id, $event)"></td>
       <td>{{ data.id }}</td>
@@ -39,18 +39,18 @@
         <nz-tag nzColor="red" *ngIf="!data.online">Offline</nz-tag>
         <ng-container *ngIf="data.subnets && data.subnets.length>0">
           <nz-tag nzColor="magenta" *ngIf="data.subnets_enabled_num>0">
-            SubNet {{data.subnets_enabled_num}}/{{data.subnets.length}}
+            {{routeSummaryLabel(data, 'subnet')}}
           </nz-tag>
           <nz-tag nzColor="default" *ngIf="data.subnets_enabled_num<=0">
-            SubNet {{data.subnets_enabled_num}}/{{data.subnets.length}}
+            {{routeSummaryLabel(data, 'subnet')}}
           </nz-tag>
         </ng-container>
         <ng-container *ngIf="data.exitNodes && data.exitNodes.length>0">
           <nz-tag nzColor="geekblue" *ngIf="data.exitNode_enabled_num>0">
-            ExitNode {{data.exitNode_enabled_num}}/{{data.exitNodes.length}}
+            {{routeSummaryLabel(data, 'exitNode')}}
           </nz-tag>
           <nz-tag nzColor="default" *ngIf="data.exitNode_enabled_num<=0">
-            ExitNode {{data.exitNode_enabled_num}}/{{data.exitNodes.length}}
+            {{routeSummaryLabel(data, 'exitNode')}}
           </nz-tag>
         </ng-container>
 
@@ -69,10 +69,7 @@
               <a nz-button nzType="link" nzSize="small" (click)="renameMachine(data)">Rename Machine</a>
             </li>
             <li nz-menu-item>
-              <a nz-button nzType="link" nzSize="small" (click)="tagEditMachine=data">Edit Tags</a>
-            </li>
-            <li nz-menu-item>
-              <a nz-button nzType="link" nzSize="small" (click)="changeOwner(data)">Change Owner</a>
+              <span style="color: rgba(0, 0, 0, 0.45);">Tags are read-only in 0.28 mode</span>
             </li>
             <li nz-menu-divider></li>
             <li nz-menu-item>
@@ -90,27 +87,16 @@
               nzTitle="Created Time">{{data.createdAt|date:'yyyy-MM-dd HH:mm:ss'}}</nz-descriptions-item>
             <nz-descriptions-item
               nzTitle="Last Seen">{{data.lastSeen|date:'yyyy-MM-dd HH:mm:ss'}}</nz-descriptions-item>
-            <nz-descriptions-item
-              nzTitle="Last Update">{{data.lastSuccessfulUpdate|date:'yyyy-MM-dd HH:mm:ss'}}</nz-descriptions-item>
             <nz-descriptions-item nzTitle="Register Method">{{data.registerMethod}}</nz-descriptions-item>
-            <nz-descriptions-item nzTitle="Forced Tags">
-              <span *ngIf="data.forcedTags.length<=0">None</span>
-              <nz-tag nzColor="cyan" *ngFor="let t of data.forcedTags">{{t}}</nz-tag>
-            </nz-descriptions-item>
-            <nz-descriptions-item nzTitle="Invalid Tags">
-              <span *ngIf="data.invalidTags.length<=0">None</span>
-              <nz-tag nzColor="volcano" *ngFor="let t of data.invalidTags">{{t}}</nz-tag>
-            </nz-descriptions-item>
-            <nz-descriptions-item nzTitle="Valid Tags">
-              <span *ngIf="data.validTags.length<=0">None</span>
-              <nz-tag nzColor="lime" *ngFor="let t of data.validTags">{{t}}</nz-tag>
+            <nz-descriptions-item nzTitle="Tags">
+              <span>{{tagLabel(data)}}</span>
             </nz-descriptions-item>
           </nz-descriptions>
         </div>
         <div nz-col nzSpan="12">
           <nz-list nzBordered nzHeader="Exit Node" nzSize="small" style="margin-bottom: 10px"
                    *ngIf="data.exitNodes && data.exitNodes.length>0">
-            <nz-list-item *ngFor="let eni of data.exitNodes">
+            <nz-list-item *ngFor="let eni of data.exitNodes; trackBy: routeTrackBy">
               <span>
                 <span *ngIf="eni.prefix==='0.0.0.0/0'">IPv4</span>
                 <span *ngIf="eni.prefix==='::/0'">IPv6</span>&nbsp;
@@ -120,24 +106,14 @@
               </span>
               <span>
                 <nz-button-group>
-                  <button nz-button nzType="default" *ngIf="!eni.enabled" [disabled]="!eni.advertised" (click)="enableRoute(eni.id)">Enable</button>
-                  <button nz-button nzType="default" *ngIf="eni.enabled" (click)="disableRoute(eni.id)">Disable</button>
-                  <button nz-button nz-dropdown [nzDropdownMenu]="menu2" nzPlacement="bottomRight">
-                    <span nz-icon nzType="ellipsis"></span>
-                  </button>
+                  <button nz-button nzType="default" *ngIf="!eni.enabled" [disabled]="!eni.advertised" (click)="enableRoute(data, eni.prefix)">Enable</button>
+                  <button nz-button nzType="default" *ngIf="eni.enabled" (click)="disableRoute(data, eni.prefix)">Disable</button>
                 </nz-button-group>
-                <nz-dropdown-menu #menu2="nzDropdownMenu">
-                  <ul nz-menu>
-                    <li nz-menu-item>
-                      <a nz-button nzDanger nzType="link" nzSize="small" (click)="deleteRoute(eni.id)">Delete Route</a>
-                    </li>
-                  </ul>
-                </nz-dropdown-menu>
               </span>
             </nz-list-item>
           </nz-list>
           <nz-list nzBordered nzHeader="Sub Nets" nzSize="small" *ngIf="data.subnets && data.subnets.length>0">
-            <nz-list-item *ngFor="let sni of data.subnets">
+            <nz-list-item *ngFor="let sni of data.subnets; trackBy: routeTrackBy">
               <span>
                 {{sni.prefix}}&nbsp;
                  <nz-tag nzColor="geekblue" *ngIf="sni.enabled">Enabled</nz-tag>
@@ -147,19 +123,9 @@
               </span>
               <span>
                 <nz-button-group>
-                  <button nz-button nzType="default" *ngIf="!sni.enabled" [disabled]="!sni.advertised" (click)="enableRoute(sni.id)">Enable</button>
-                  <button nz-button nzType="default" *ngIf="sni.enabled" (click)="disableRoute(sni.id)">Disable</button>
-                  <button nz-button nz-dropdown [nzDropdownMenu]="menu3" nzPlacement="bottomRight">
-                    <span nz-icon nzType="ellipsis"></span>
-                  </button>
+                  <button nz-button nzType="default" *ngIf="!sni.enabled" [disabled]="!sni.advertised" (click)="enableRoute(data, sni.prefix)">Enable</button>
+                  <button nz-button nzType="default" *ngIf="sni.enabled" (click)="disableRoute(data, sni.prefix)">Disable</button>
                 </nz-button-group>
-                <nz-dropdown-menu #menu3="nzDropdownMenu">
-                  <ul nz-menu>
-                    <li nz-menu-item>
-                      <a nz-button nzDanger nzType="link" nzSize="small" (click)="deleteRoute(sni.id)">Delete Route</a>
-                    </li>
-                  </ul>
-                </nz-dropdown-menu>
               </span>
             </nz-list-item>
           </nz-list>
@@ -169,27 +135,3 @@
   </ng-container>
   </tbody>
 </nz-table>
-<nz-modal [nzVisible]="changeOwnerMachine.id" [nzTitle]="'Change Machine Owner: '+changeOwnerMachine.givenName"
-          (nzOnOk)="doChangeOwner()" [nzClosable]="false" nzWidth="460px" (nzOnCancel)="changeOwnerMachine={}">
-  <ng-container *nzModalContent>
-    <nz-select [(ngModel)]="changeOwnerUser" style="width: 100%;">
-      <nz-option [nzValue]="u.name" [nzLabel]="u.name" *ngFor="let u of users"></nz-option>
-    </nz-select>
-  </ng-container>
-</nz-modal>
-
-<nz-modal [nzVisible]="tagEditMachine.id" [nzTitle]="'Change Machine Tags: '+tagEditMachine.givenName"
-          [nzMaskClosable]="false"
-          nzWidth="460px" nzCancelText="Close" [nzOkText]="null" (nzOnCancel)="tagEditMachine={}">
-  <ng-container *nzModalContent>
-    <nz-tag *ngFor="let tag of tagEditMachine.forcedTags;" nzMode="closeable" (nzOnClose)="handleClose(tag)">{{tag}}</nz-tag>
-    <nz-tag *ngIf="!inputVisible" class="editable-tag" nzNoAnimation (click)="showInput()">
-      <span nz-icon nzType="plus"></span>
-      New Tag
-    </nz-tag>
-    <input #inputElement nz-input nzSize="small" *ngIf="inputVisible" type="text"
-           [(ngModel)]="inputValue" style="width: 78px;" (blur)="handleInputConfirm()"
-           (keydown.enter)="handleInputConfirm()"
-    />
-  </ng-container>
-</nz-modal>

--- a/src/app/views/machine-manager/machine-manager.component.ts
+++ b/src/app/views/machine-manager/machine-manager.component.ts
@@ -1,4 +1,4 @@
-import {Component, ElementRef, OnInit, ViewChild, ViewContainerRef} from '@angular/core';
+import {Component, OnInit, ViewContainerRef} from '@angular/core';
 import {ApiService} from '../../api.service';
 import {ActivatedRoute, Router} from '@angular/router';
 import {OneInputComponent} from '../../components/one-input/one-input.component';
@@ -16,15 +16,6 @@ export class MachineManagerComponent implements OnInit {
   machines: Array<any> = [];
   user = '';
   users: Array<any> = [];
-
-  changeOwnerMachine: any = {};
-  tagEditMachine: any = {}
-  changeOwnerUser: string = '';
-
-  tags = ['Unremovable', 'Tag 2', 'Tag 3'];
-  inputVisible = false;
-  inputValue = '';
-  @ViewChild('inputElement', {static: false}) inputElement?: ElementRef;
 
   constructor(private api: ApiService, private route: ActivatedRoute, private msg: NzMessageService,
               private modal: NzModalService, private viewContainerRef: ViewContainerRef,
@@ -50,77 +41,100 @@ export class MachineManagerComponent implements OnInit {
   }
 
   getList() {
-    let version = localStorage.getItem('serverUrl') ?? 'v0.23';
-
-      this.api.machineList(this.user).subscribe(x => {
-        if (version === 'v0.23'){
-          this.machines = x.nodes.sort((a: any, b: any) => parseInt(a.id) - parseInt(b.id));
-        }else{
-          this.machines = x.machines.sort((a: any, b: any) => parseInt(a.id) - parseInt(b.id));
-        }
-        this.getRoutes();
-        if (this.tagEditMachine.id) {
-          this.tagEditMachine = this.machines.find(x => x.id == this.tagEditMachine.id);
-        }
-      });
-    
-    
+    this.api.machineList(this.user).subscribe(x => {
+      this.machines = (x.nodes ?? [])
+        .map((node: any) => this.normalizeMachine(node))
+        .sort((a: any, b: any) => parseInt(a.id) - parseInt(b.id));
+    });
   }
 
-  getRoutes() {
-    this.api.routeList().subscribe(x => {
-      for (let r of x.routes) {
-        let m = this.machines.find(x => x.id === r.node.id);
-        if (m) {
-          if (['0.0.0.0/0', '::/0'].indexOf(r.prefix) !== -1) {
-            if (m['exitNodes']) {
-              m['exitNodes'].push(r);
-            } else {
-              m['exitNodes'] = [r]
-            }
-          } else {
-            if (m['subnets']) {
-              m['subnets'].push(r);
-            } else {
-              m['subnets'] = [r]
-            }
-          }
-        }
-      }
-      for (let m of this.machines) {
-        if (m.subnets) {
-          m['subnets_enabled_num'] = m.subnets.filter((sn: { enabled: any; }) => sn.enabled).length;
-        }
-        if (m.exitNodes) {
-          m['exitNode_enabled_num'] = m.exitNodes.filter((sn: { enabled: any; }) => sn.enabled).length;
-        }
-      }
-    })
+  normalizeMachine(node: any) {
+    const approvedRoutes = node.approvedRoutes ?? [];
+    const routePrefixes = Array.from(new Set([
+      ...(node.availableRoutes ?? []),
+      ...approvedRoutes,
+      ...(node.subnetRoutes ?? [])
+    ]));
+    const routes = routePrefixes.map((prefix: string) => ({
+      nodeId: node.id,
+      prefix,
+      advertised: (node.availableRoutes ?? []).includes(prefix) || (node.subnetRoutes ?? []).includes(prefix),
+      enabled: approvedRoutes.includes(prefix),
+      isPrimary: false
+    }));
+    const exitNodes = routes.filter(route => ['0.0.0.0/0', '::/0'].includes(route.prefix));
+    const subnets = routes.filter(route => !['0.0.0.0/0', '::/0'].includes(route.prefix));
+
+    return {
+      ...node,
+      tags: node.tags ?? [],
+      exitNodes,
+      subnets,
+      subnets_enabled_num: subnets.filter(route => route.enabled).length,
+      exitNode_enabled_num: exitNodes.filter(route => route.enabled).length,
+      lastSuccessfulUpdate: null
+    };
   }
 
-  onExpandChange(id: string, checked: boolean): void {
-    if (checked) {
-      this.expandSet.add(id);
-    } else {
-      this.expandSet.delete(id);
+  setRouteState(machine: any, prefix: string, enabled: boolean) {
+    const currentRoutes = machine.approvedRoutes ?? [];
+    const nextRoutes = enabled
+      ? Array.from(new Set([...currentRoutes, prefix]))
+      : currentRoutes.filter((route: string) => route !== prefix);
+
+    this.api.machineSetApprovedRoutes(machine.id, nextRoutes).subscribe(() => {
+      this.msg.success(`Route ${enabled ? 'Enable' : 'Disable'} success`);
+      this.getList();
+    });
+  }
+
+  enableRoute(machine: any, prefix: string) {
+    this.setRouteState(machine, prefix, true);
+  }
+
+  disableRoute(machine: any, prefix: string) {
+    this.setRouteState(machine, prefix, false);
+  }
+
+  routeTrackBy(_: number, route: any) {
+    return `${route.nodeId}:${route.prefix}`;
+  }
+
+  machineTrackBy(_: number, machine: any) {
+    return machine.id;
+  }
+
+  routeSummaryLabel(machine: any, type: 'subnet' | 'exitNode') {
+    if (type === 'subnet') {
+      return `SubNet ${machine.subnets_enabled_num}/${machine.subnets.length}`;
     }
+
+    return `ExitNode ${machine.exitNode_enabled_num}/${machine.exitNodes.length}`;
+  }
+
+  tagLabel(machine: any) {
+    if (machine.tags.length === 0) {
+      return 'None';
+    }
+
+    return machine.tags.join(', ');
   }
 
   renameMachine(machine: any) {
     this.modal.create({
-      nzTitle: `Rename User - ${machine.givenName}`,
+      nzTitle: `Rename Machine - ${machine.givenName}`,
       nzComponentParams: {notice: machine.givenName},
       nzContent: OneInputComponent,
       nzViewContainerRef: this.viewContainerRef,
       nzFooter: null
     }).afterClose.subscribe(x => {
       if (x) {
-        this.api.machineRename(machine.id, x).subscribe(x => {
+        this.api.machineRename(machine.id, x).subscribe(() => {
           this.msg.success('Machine Rename success');
           this.getList();
-        })
+        });
       }
-    })
+    });
   }
 
   deleteMachine(machine: any) {
@@ -134,30 +148,17 @@ export class MachineManagerComponent implements OnInit {
         this.api.machineDelete(machine.id).subscribe(_ => {
           this.msg.success('Machine delete success');
           this.getList();
-        })
+        });
       }
     });
   }
 
-  enableRoute(id: string) {
-    this.api.routeEnable(id).subscribe(x => {
-      this.msg.success('Route Enable success');
-      this.getList();
-    })
-  }
-
-  disableRoute(id: string) {
-    this.api.routeDisable(id).subscribe(x => {
-      this.msg.success('Route Disable success');
-      this.getList();
-    })
-  }
-
-  deleteRoute(id: string) {
-    this.api.routeDelete(id).subscribe(x => {
-      this.msg.success('Route Delete success');
-      this.getList();
-    })
+  onExpandChange(id: string, checked: boolean): void {
+    if (checked) {
+      this.expandSet.add(id);
+    } else {
+      this.expandSet.delete(id);
+    }
   }
 
   userChange(e: any) {
@@ -176,61 +177,16 @@ export class MachineManagerComponent implements OnInit {
     this.modal.create({
       nzTitle: `Register Machine For User: ${this.user}`,
       nzContent: OneInputComponent,
-      nzComponentParams: {notice: 'nodekey:xxxxxxxxxxxxxxxxxxxxxx'},
+      nzComponentParams: {notice: 'Registration ID (24 chars)'},
       nzViewContainerRef: this.viewContainerRef,
       nzFooter: null
     }).afterClose.subscribe(x => {
       if (x) {
-        this.api.machineRegister(this.user, 'nodekey:' + x.replace('nodekey:', '')).subscribe(x => {
+        this.api.machineRegister(this.user, x.trim()).subscribe(() => {
           this.msg.success('Register machine success');
           this.getList();
-        })
+        });
       }
-    })
-  }
-
-  changeOwner(m: any) {
-    this.changeOwnerMachine = m;
-  }
-
-  doChangeOwner() {
-    if (!this.changeOwnerUser) {
-      this.msg.error('Must select one user')
-      return;
-    }
-    this.api.machineChangeUser(this.changeOwnerMachine.id, this.changeOwnerUser).subscribe(_ => {
-      this.msg.success('Machine change owner success')
-      this.getList();
-      this.changeOwnerMachine = {}
-    })
-  }
-
-  handleClose(removedTag: {}): void {
-    this.tagEditMachine.forcedTags = this.tagEditMachine.forcedTags.filter((tag: {}) => tag !== removedTag);
-    this.updateTags(this.tagEditMachine.forcedTags);
-  }
-
-  showInput(): void {
-    this.inputVisible = true;
-    setTimeout(() => {
-      this.inputElement?.nativeElement.focus();
-    }, 10);
-  }
-
-  handleInputConfirm(): void {
-    if (this.inputValue && this.tagEditMachine.forcedTags.indexOf(this.inputValue) === -1) {
-      this.tagEditMachine.forcedTags = [...this.tagEditMachine.forcedTags, this.inputValue];
-    }
-    this.inputValue = '';
-    this.inputVisible = false;
-    this.updateTags(this.tagEditMachine.forcedTags);
-  }
-
-  updateTags(tags: Array<string>) {
-    this.api.machineTag(this.tagEditMachine.id, tags).subscribe(_ => {
-    }, _ => {
-    }, () => {
-      this.getList();
-    })
+    });
   }
 }

--- a/src/app/views/user-manager/user-manager.component.html
+++ b/src/app/views/user-manager/user-manager.component.html
@@ -17,13 +17,13 @@
   <tbody>
   <ng-container *ngFor="let data of nzTable.data">
     <tr>
-      <td [nzExpand]="expandSet.has(data.name)" (nzExpandChange)="onExpandChange(data.name, $event)"></td>
+      <td [nzExpand]="expandSet.has(data.id)" (nzExpandChange)="onExpandChange(data, $event)"></td>
       <td>{{ data.id }}</td>
       <td>{{ data.name }}</td>
       <td>{{ data.createdAt | date: 'yyyy-MM-dd HH:mm:ss' }}</td>
       <td>
         <nz-button-group>
-          <button nz-button (click)="onExpandChange(data.name,!expandSet.has(data.name))">PreAuthKeys
+          <button nz-button (click)="onExpandChange(data,!expandSet.has(data.id))">PreAuthKeys
           </button>
           <button nz-button nz-dropdown [nzDropdownMenu]="menu" nzPlacement="bottomRight">
             <span nz-icon nzType="ellipsis"></span>
@@ -32,22 +32,22 @@
         <nz-dropdown-menu #menu="nzDropdownMenu">
           <ul nz-menu>
             <li nz-menu-item>
-              <a nz-button nzType="link" nzSize="small" (click)="createPreAuthKey(data.name)">Create PreAuthKey</a>
+              <a nz-button nzType="link" nzSize="small" (click)="createPreAuthKey(data)">Create PreAuthKey</a>
             </li>
             <li nz-menu-item>
-              <a nz-button nzType="link" nzSize="small" (click)="renameUser(data.name)">Rename User</a>
+              <a nz-button nzType="link" nzSize="small" (click)="renameUser(data)">Rename User</a>
             </li>
             <li nz-menu-divider></li>
             <li nz-menu-item>
-              <a nz-button nzDanger nzType="link" nzSize="small" (click)="deleteUser(data.name)">Delete User</a>
+              <a nz-button nzDanger nzType="link" nzSize="small" (click)="deleteUser(data)">Delete User</a>
             </li>
           </ul>
         </nz-dropdown-menu>
       </td>
     </tr>
-    <tr [nzExpand]="expandSet.has(data.name)">
+    <tr [nzExpand]="expandSet.has(data.id)">
       <nz-list nzBordered nzSize="small">
-        <nz-list-item *ngFor="let pak of preAuthKeys[data.name]">
+        <nz-list-item *ngFor="let pak of preAuthKeys[data.id]">
           <span>
             {{pak.key}}
             <nz-tag nzColor="blue">Expiration:{{pak.expiration|date:'yyyy-MM-dd HH:mm:ss'}}</nz-tag>
@@ -57,7 +57,7 @@
           </span>
           <ul nz-list-item-actions>
             <nz-list-item-action>
-              <a (click)="expirePreAuthKey(pak)">Expire</a>
+              <a (click)="expirePreAuthKey(data, pak)">Expire</a>
             </nz-list-item-action>
           </ul>
         </nz-list-item>

--- a/src/app/views/user-manager/user-manager.component.ts
+++ b/src/app/views/user-manager/user-manager.component.ts
@@ -30,18 +30,18 @@ export class UserManagerComponent implements OnInit {
     });
   }
 
-  getPreAuthKeys(user: string) {
-    this.api.preAuthKeyList(user).subscribe(x => {
-      this.preAuthKeys[user] = x.preAuthKeys;
-    })
+  getPreAuthKeys(user: any) {
+    this.api.preAuthKeyList().subscribe(x => {
+      this.preAuthKeys[user.id] = (x.preAuthKeys ?? []).filter((key: any) => key.user?.id === user.id);
+    });
   }
 
-  onExpandChange(name: string, checked: boolean): void {
+  onExpandChange(user: any, checked: boolean): void {
     if (checked) {
-      this.expandSet.add(name);
-      this.getPreAuthKeys(name);
+      this.expandSet.add(user.id);
+      this.getPreAuthKeys(user);
     } else {
-      this.expandSet.delete(name);
+      this.expandSet.delete(user.id);
     }
   }
 
@@ -61,47 +61,47 @@ export class UserManagerComponent implements OnInit {
     })
   }
 
-  renameUser(name: string) {
+  renameUser(user: any) {
     this.modal.create({
-      nzTitle: `Rename User - ${name}`,
-      nzComponentParams: {notice: name},
+      nzTitle: `Rename User - ${user.name}`,
+      nzComponentParams: {notice: user.name},
       nzContent: OneInputComponent,
       nzViewContainerRef: this.viewContainerRef,
       nzFooter: null
     }).afterClose.subscribe(x => {
       if (x) {
-        this.api.userRename(name, x).subscribe(x => {
+        this.api.userRename(user.id, x).subscribe(() => {
           this.msg.success('User Rename success');
           this.getList();
-        })
-      }
-    })
-  }
-
-  deleteUser(name: string) {
-    this.modal.warning({
-      nzTitle: 'Delete Confirm',
-      nzContent: `will delete user 【 ${name} 】 ,Are you sure？`,
-      nzOkDanger: true,
-      nzOkText: 'Delete',
-      nzCancelText: 'cancel',
-      nzOnOk: () => {
-        this.api.userDelete(name).subscribe(_ => {
-          this.msg.success('User delete success');
-          this.getList();
-        })
+        });
       }
     });
   }
 
-  createPreAuthKey(name: string) {
-    this.api.preAuthKeyAdd(name, '9999-03-23T13:41:44.928Z').subscribe(_ => {
-      this.msg.success('Create PreAuthKey success')
-      this.getPreAuthKeys(name);
-    })
+  deleteUser(user: any) {
+    this.modal.warning({
+      nzTitle: 'Delete Confirm',
+      nzContent: `will delete user 【 ${user.name} 】 ,Are you sure？`,
+      nzOkDanger: true,
+      nzOkText: 'Delete',
+      nzCancelText: 'cancel',
+      nzOnOk: () => {
+        this.api.userDelete(user.id).subscribe(_ => {
+          this.msg.success('User delete success');
+          this.getList();
+        });
+      }
+    });
   }
 
-  expirePreAuthKey(key: any) {
+  createPreAuthKey(user: any) {
+    this.api.preAuthKeyAdd(user.id, '9999-03-23T13:41:44.928Z').subscribe(_ => {
+      this.msg.success('Create PreAuthKey success');
+      this.getPreAuthKeys(user);
+    });
+  }
+
+  expirePreAuthKey(user: any, key: any) {
     this.modal.warning({
       nzTitle: 'Expire Confirm',
       nzContent: `will expire PreAuthKey 【 ${key.key} 】 ,Are you sure？`,
@@ -109,10 +109,10 @@ export class UserManagerComponent implements OnInit {
       nzOkText: 'Expire It',
       nzCancelText: 'cancel',
       nzOnOk: () => {
-        this.api.preAuthKeyExpire(key.user, key.key).subscribe(_ => {
+        this.api.preAuthKeyExpire(key.id).subscribe(_ => {
           this.msg.success('Expire PreAuthKey success');
-          this.getPreAuthKeys(key.user);
-        })
+          this.getPreAuthKeys(user);
+        });
       }
     });
   }


### PR DESCRIPTION
 ## Summary

  This PR updates the UI for Headscale v0.28 and refreshes the README to reflect the current API direction and support
  status.

  The implementation and validation for this change were completed with Codex using GPT-5.4.

  ## What changed

  - switched client node operations to the `/api/v1/node` API used by Headscale v0.28
  - removed legacy `/api/v1/machine/...` branches from the Angular API service
  - updated user operations to use user IDs where required by newer handlers
  - updated pre-auth key operations to match current request and response shapes
  - replaced legacy route management calls with node approved-route updates
  - changed the login default to `v0.28`
  - improved login error handling
  - updated the README for current compatibility and limitations

  This is not a relocation of the old machine API implementation. The legacy machine endpoint branches were removed, and
  the client now standardizes on the newer node API flow.


  In `v0.28` mode, tag editing is currently treated as read-only in the machine view.

  ## Validation
  Validated against Headscale `v0.28` for:

  - login
  - user list / rename / delete
  - node list
  - node register / rename / expire / delete
  - route approval updates
  - pre-auth key list / create / expire